### PR TITLE
wysylki na jutro dla firm spoza top30

### DIFF
--- a/resources/views/emails/company/ebe6-earlybird-reminder-de.blade.php
+++ b/resources/views/emails/company/ebe6-earlybird-reminder-de.blade.php
@@ -4,25 +4,20 @@
 
 # Hi {{ array_get($profile, "fname") }},
 
-die E-commerce Berlin Expo 2020 gehört der Vergangenheit an, jedoch laufen die Vorbereitungen für die Expo 2021 (18.02.2021 @ STATION Berlin) auf Hochtouren. 
+Wir wollen dich auf den Beginn des exklusiven Early-Bird-Sales' aufmerksam machen, der nur für die Aussteller der letzten Expo vorgesehen ist. Dieser beginnt am Donnerstag, den 05.03.20 ab 12 Uhr.
 
-# Wir möchten dich darüber informieren, dass am kommenden Donnerstag, **den 05.03.2020, ab 12 Uhr**, der Vorverkauf für die anstehende Expo beginnt. 
+# Reservierungen in diesem Salespool sind nur bis zum 31.03.20 möglich. Danach gibt es keinen Early-Bird mehr und die Preise werden steigen.
 
-Was sind die Vorteile? 
 
-* Zugang zu den Topflächen zum günstigsten Preis 
-* Sichere dir die Toplocation 
-* sichere dir den Topplatz vor der Konkurrenz 
-
-Die Preise beginnen ab 2500€ für 9m2 bis zu 5200€ für 18m2. 
-
-Der nachfolgende Link bringt euch zur Bookingseite. Dort werdet ihr die Preise sehen. 
+Der Link unten wird dich zur Bookingseite weiterleiten wo du alle Standflächen sehen wirst. 
 
 @component('mail::button', ['url' => "https://ecommerceberlin.com/exhibit"])
-Check the map here
+hier zur Bookingseite
 @endcomponent
 
-**WICHTIG!** Bitte beachte, dass der Vorverkauf bis zum 31.03.2020 offen ist. Danach werden die Preise steigen und du wirst nicht mehr die Möglichkeit haben, die Standfläche zu den oben genannten Konditionen zu bekommen. 
+**WICHTIG!** 
+Es kann sein, dass einige Flächen mit einem „R“ versehen sind, d.h diese Standfläche ist bereits vergeben, da die TOP30 aus dem Ausstellerwettbewerb diese bereits ergattert haben. Diese Flächen werden dann nicht mehr verfügbar sein. 
+Der Early-Bird-Verkauf wird bis zum 31.03 gültig sein. Danach wird es nicht mehr möglich sein, die Flächen zu den Preisen zu buchen. 
 
 Mit freundlichen Grüßen,
 

--- a/resources/views/emails/company/ebe6-earlybird-reminder-en.blade.php
+++ b/resources/views/emails/company/ebe6-earlybird-reminder-en.blade.php
@@ -4,25 +4,19 @@
  
 # Hello {{ array_get($profile, "fname") }},
 
-The E-commerce Berlin Expo 2020 is past but the preparations for the Expo 2021 (18.02.2021 @ STATION Berlin) have already started. 
+We would like to kindly remind you about the **limited Early Bird sales round for Exhibitors of the previous edition of the E-commerce Berlin Expo by **tomorrow, 5th March 2020 from 12:00 PM**.
 
-# We would like to inform you that on next Thursday, the **5th of March 2020, from 12:00 pm**, the Early Bird sales starts.
+# You can make reservations for the Early Bird price only until the end of the month (31.03.20). After this date, the Early Bird offer will expire and the prices for exhibition spaces will increase.
 
-What are the benefits of it? 
-
-* get access to the top locations on a lower price 
-* secure a premium spot 
-* be faster than your competitors 
-
-The fees will start from 2500€ for 9m2 up to 5200€ for 18m2. 
-
-The following link will show you the stands and pricing.
+The link below will redirect you to the booking map where you will see all the exhibition spaces available. 
 
 @component('mail::button', ['url' => "https://ecommerceberlin.com/exhibit"])
 Check the map here
 @endcomponent
 
-**ATTENTION!** Please be aware that the Early Bird sales pool will be active until the 31st of March. Afterwards, the fees will increase and you won’t be able to book a spot on the above mentioned prices.
+**ATTENTION!** 
+Please be aware that some of the spots are already booked and marked as "R" for companies from the recent Exhibitors' Contest. These exhibition space won't be available in the sales process. 
+The Early Bird sales pool will be active until the 31st of March. Afterwards, the fees will increase and you won't be able to book a spot on the above mentioned prices.
 
 Best regards,
 


### PR DESCRIPTION
temat

EN The Early Bird sales round for E-commerce Berlin Expo 2021 starts tomorrow morning (5th March 2020)

DE Achtung, fertig, LOS! Der Early-Bird-Verkauf beginnt Morgen (05.03.2020) - E-commerce Berlin Expo 2021