### PR TITLE
poprawki

### DIFF
--- a/resources/views/emails/company/ebe6-new-date-released-de.blade.php
+++ b/resources/views/emails/company/ebe6-new-date-released-de.blade.php
@@ -1,0 +1,28 @@
+@component('mail::message')
+ 
+# Hallo {{ array_get($profile, "fname") }},
+
+In Bezug auf die bestehenden COVID-19 Beschränkungen in Bezug auf Präsenzveranstaltungen und die Sorge der Menschen, die COVID-19 mit sich trägt haben wir uns dazu entschlossen, **die E-commerce Berlin Expo 2021 auf den 27.05.2021 zu verschieben**
+
+Wir waren der festen Überzeugung, dass wir in der Lage sind, die Veranstaltung mit allen geltenden Einschränkungen zu organisieren, aber die Bedenken hinsichtlich der Anzahl der Personen, die bei dem Event im Februar teilnehmen würden, unserer Verpflichtung, der Gesundheit der Teilnehmer Priorität einzuräumen, die höchsten organisatorischen Standards zu ermöglichen und dem Gesamtergebnis einer rundum zufriedenstellenden Veranstaltung zu gewährleisten brachten uns dazu, diese Entscheidung zu treffen.
+
+Dazu kommt, dass wir mit vielen aktuellen Ausstellern und Unternehmen, die ausstellen wollen würden gesprochen haben und für sie nur ein Präsenzveranstaltung in Frage kommt. Wir sind uns dessen bewusst, wie wichtig und ergebnisorientiert Vororttreffen sind und deswegen nehmen wir auch von einer Hybrid/Digitalorganisation Abstand, da sie nicht denselben Effekt mit sich bringen würden
+
+Damit das geschieht und die Erwartungen der Teilnehmer/innen erfüllt werden **bleiben wir bei der Präsenzform und nehmen von der digitalen/Hybrid Organisation konsequent Abstand.**
+
+In Bezug auf das oben genannte und der Verschiebung unseres Hauptprojekts - der E-commerce Berlin Expo auf den 27.05.21 - **haben wir uns auch dazu entschlossen, die Bewerbungsfrist für die E-commerce Germany Awards 2021 zu verlängern. Bewerbungsende ist hier der 8.01.2021.**
+
+Wir bedanken uns für euren kontinuierlichen Support und wünschen euch alles erdenklich Gute für die kommenden Monate.
+
+Wir freuen uns euch im Mai nächsten Jahres zu sehen.
+Lieben Gruß,
+
+
+<img src="https://res.cloudinary.com/ecommerceberlin/image/upload/v1606743599/images/podpisy_mt_psz.png" alt="signatures" style="max-width: 250px;">
+
+Peter Szczepaniak & Mark Tomaszewski
+
+Managing Partners, E-commerce Berlin Expo
+
+
+@endcomponent

--- a/resources/views/emails/company/ebe6-new-date-released-en.blade.php
+++ b/resources/views/emails/company/ebe6-new-date-released-en.blade.php
@@ -1,0 +1,35 @@
+
+
+@component('mail::message')
+ 
+# Hello {{ array_get($profile, "fname") }},
+
+Due to the current COVID-19 restrictions for organizing trade fairs and conferences, as well as public concern about the course of the COVID-19 pandemic, **we have decided to postpone the event until May 27th, 2021.**
+
+We had strongly believed that we were capable of organizing the event with all applicable restrictions. Concern about a low number of people who would still attend the event in February, our commitment to prioritizing the health of attendees, as well as our care about the highest organizational standards and the overall outcome (ROI) of the event, forced us to make this decision.
+
+
+Additionally, we’ve talked both to many current exhibitors and companies interested in participating as exhibitors, and they expressed their interest almost exclusively in a physical/on-site formula of our event. We know how important and fruitful face-to-face meetings are for all parties, and therefore hybrid or digital events may not live up to high E-commerce Berlin Expo standards.
+
+
+In order to meet participants’ expectations, **we’d like to keep the initially proposed formula of our event. Hybrid or online versions are therefore not considered as a substitute in this case.**
+
+In relation to the decision about postponing our main project, E-commerce Berlin Expo, until May 27th, 2021, **we have also decided to extend the deadline for submissions for the E-commerce Germany Awards until January 8th, 2021.**
+
+
+We would like to thank you for your continued support and wish you all the best for the upcoming months.
+We’re looking forward to seeing you in May!
+
+Best regards,
+
+
+Peter Szczepaniak & Mark Tomaszewski
+Managing Partners, E-commerce Berlin Expo
+
+
+<LINK DO GRAFIKI Z PODPISAMI ZNAJDUJE SIĘ W KOMENTARZU DO PULLa  >
+
+@endcomponent
+
+
+


### PR DESCRIPTION
temat DE
Die E-commerce Berlin Expo 2021 wird verschoben - neues Datum

temat EN
The E-commerce Berlin Expo 2021 has been postponed. Check the new date of the event.