### PR TITLE
New date announcement emails

### DIFF
--- a/resources/views/emails/company/ebe6-second-event-postponement-de.blade.php
+++ b/resources/views/emails/company/ebe6-second-event-postponement-de.blade.php
@@ -1,0 +1,37 @@
+
+@component('mail::message')
+ 
+# Hello {{ array_get($profile, "fname") }},
+
+
+Wir sind immer noch mit den Auswirkungen von COVID-19 konfrontiert und können nicht vorhersagen, welche Schritte die Bundesregierung und die Gesundheitsbehörden unternehmen werden. Daher möchten wir euch über unsere nächsten Schritte informieren. 
+
+In diesem Zusammenhang haben wir vom E-Commerce Berlin Expo-Team beschlossen, die E-Commerce Berlin Expo 2021, die am 27. Mai als Vor-Ort-Veranstaltung stattfinden sollte, zu verschieben.
+
+Es gibt mehrere Gründe für diese Verschiebung: 
+
+Unter Berücksichtigung der aktuellen Umstände, die auf der aktuellen Anzahl der Personen basieren, die an Veranstaltungen teilnehmen dürfen (z. B. sind Veranstaltungen in Innenräumen derzeit auf 20 Personen begrenzt), und der Unsicherheit hinsichtlich der Erhöhung der Obergrenze erwarten wir keine Veranstaltung mit mindestens 3.000 Menschen, die im Mai zu organisieren wäre.
+
+Mit Bedenken hinsichtlich einer geringen Teilnehmerzahl im Mai haben wir diese Entscheidung getroffen, weil uns die Gesundheit und Sicherheit der Teilnehmer/innen, aber auch die höchsten organisatorischen Standards und der Verkehr der Veranstaltung am Herzen liegen.
+
+Um die Erwartungen der Teilnehmer/innen zu erfüllen, möchten wir die Veranstaltung wie ursprünglich vorgeschlagen beibehalten, was uns zu dem Schluss bringt, dass sie im Februar 2022 als Vor-Ort-Veranstaltung zurückkehren wird. Dazu sei gesagt, dass wir zwischen dem 26-27.05 eine virtuelle Konferenz organisieren werden.
+
+
+**Darüber hinaus werden die mit Euren Buchungen verbundenen Dienstleistungen und Verpflichtungen ohne zusätzliche Kosten auf den neuen Termin übertragen.**
+
+Wir bedanken uns für eure kontinuierliche Unterstützung und wünschen euch für die kommenden Monate nur das Beste! 
+
+Wir freuen uns bald von Euch zu hören,
+
+Mit freundlichen Grüßen,
+
+<img src="https://res.cloudinary.com/ecommerceberlin/image/upload/v1606743599/images/podpisy_mt_psz.png" alt="signatures" style="max-width: 300px;">
+
+Peter Szczepaniak & Mark Tomaszewski
+
+Managing Partners, E-commerce Berlin Expo
+
+@endcomponent
+
+
+

--- a/resources/views/emails/company/ebe6-second-event-postponement-en.blade.php
+++ b/resources/views/emails/company/ebe6-second-event-postponement-en.blade.php
@@ -1,0 +1,38 @@
+
+
+@component('mail::message')
+ 
+# Hello {{ array_get($profile, "fname") }},
+
+
+We are still facing the impact of COVID-19 and can’t predict what steps the German government and the health authorities will take, so we would like to inform you all about our next steps. 
+
+In this regard, we at the E-commerce Berlin Expo team have decided to postpone the E-commerce Berlin Expo 2021, which was supposed to take place on the 27th of May as an onsite event.
+
+There are several reasons for this postponement: 
+
+Taking into account the current circumstances, which are based on the current number of people permitted to attend events (for example, indoor events are limited to 20 people at present) and uncertainty regarding the upper limit increasing, we do not expect an event with at least 3,000 people to be possible in May.
+
+With concerns about low attendee turnout in May, we made this decision because we care about the health and safety of attendees but also about the highest organizational standards and ROI of the event.
+
+In order to meet participants' expectations we'd like to keep the event as originally proposed, which brings us to the conclusion that it will return as an onsite event in February 2022. On top of that, we are preparing a virtual conference which will take place on May 26-27th.
+
+**In addition, the services and obligations associated with your bookings will be carried over to the new date without additional charges.**
+
+Please accept our sincerest gratitude for your continued support and best wishes for the coming months.
+
+
+Looking forward to hearing from you,
+
+Best regards,
+
+<img src="https://res.cloudinary.com/ecommerceberlin/image/upload/v1606743599/images/podpisy_mt_psz.png" alt="signatures" style="max-width: 300px;">
+
+Peter Szczepaniak & Mark Tomaszewski
+
+Managing Partners, E-commerce Berlin Expo
+
+@endcomponent
+
+
+


### PR DESCRIPTION
E-mail subjects:
ENG: E-commerce Berlin Expo 2022 - new date announced!
DE: E-commerce Berlin Expo 2022 - das neue Datum ist bekannt!